### PR TITLE
fix: guard missing chat legacy snapshot

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28234,7 +28234,9 @@ function ContextRecommendations(props) {
   const useSession = props.useSession;
   const useInput = props.useInput;
   const inputActions = props.inputActions;
-  const nodes = useSession?.((s) => s.chat.legacy.nodes);
+  const nodes = useSession?.(
+    (s) => s?.chat?.legacy?.nodes
+  );
   const draft = useInput?.((s) => s.draft) ?? "";
   const userText = (0, import_react25.useMemo)(() => {
     if (!nodes) return "";
@@ -29335,7 +29337,9 @@ ${sp.body ?? ""}`.trim()).join("\n\n---\n\n") : T?.("pl.monitor.none") ?? "\u65E
     });
   };
   const personaSourceLabel = (src) => src === "session" ? T?.("pl.monitor.srcSession") ?? "\u5355\u4F1A\u8BDD" : src === "path" ? T?.("pl.monitor.srcPath") ?? "\u5DE5\u4F5C\u533A" : T?.("pl.monitor.srcDefault") ?? "\u9ED8\u8BA4";
-  const nodes = useSession((s) => s.chat.legacy.nodes);
+  const nodes = useSession(
+    (s) => s?.chat?.legacy?.nodes
+  );
   const [velocityHistory, setVelocityHistory] = (0, import_react28.useState)([]);
   const trajectory = useSession(
     (s) => s.views.get("trajectory")

--- a/src/client/components/data/ContextRecommendations.tsx
+++ b/src/client/components/data/ContextRecommendations.tsx
@@ -163,7 +163,10 @@ export function ContextRecommendations(props: DockProps): ReactNode {
 
   // 宿主注入的钩子必须在组件顶层调用（不能放进 useMemo）；会话存在时必定注入，
   // 缺失时（理论上不会发生）整个组件不渲染
-  const nodes = useSession?.((s) => s.chat.legacy.nodes) as readonly ConversationNode[] | undefined;
+  const nodes = useSession?.((s) =>
+    (s as unknown as { chat?: { legacy?: { nodes?: readonly ConversationNode[] } } } | undefined)
+      ?.chat?.legacy?.nodes,
+  );
   const draft = useInput?.((s) => s.draft) ?? "";
 
   // 会话上下文：最近几条用户消息的文本（宿主 StatsLine 读取聊天历史的同一途径）

--- a/src/client/components/monitor/TokenMonitorView.tsx
+++ b/src/client/components/monitor/TokenMonitorView.tsx
@@ -230,7 +230,10 @@ export function TokenMonitorView(props: MonitorProps): null | ReactNode {
         ? (T?.("pl.monitor.srcPath") ?? "工作区")
         : (T?.("pl.monitor.srcDefault") ?? "默认");
 
-  const nodes = useSession((s) => s.chat.legacy.nodes) as readonly ConversationNode[] | undefined;
+  const nodes = useSession((s) =>
+    (s as unknown as { chat?: { legacy?: { nodes?: readonly ConversationNode[] } } } | undefined)
+      ?.chat?.legacy?.nodes,
+  );
 
   // Token 流速历史：记录每轮对话的输入/输出 token 数，用于绘制折线图（最多保留 50 轮）
   interface TokenVelocityPoint {


### PR DESCRIPTION
## Summary
- guard both prompt recommendations and token monitor against missing `chat.legacy`
- regenerate the published client bundle

Closes #2

## Verification
- `npm run build` passes
- `git diff --check` passes
- `npm run typecheck` remains blocked by the repository baseline: missing DSH peer type packages (`@deepseek-ai/dsh-client-runtime`, `@deepseek-ai/dsh-llm`, `@deepseek-ai/dsh-host-webserver`) and existing implicit-any errors

## Scope
No behavior change when the host provides the normal chat snapshot; missing/partial snapshots now degrade to no nodes instead of throwing.